### PR TITLE
remove nilearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
         "argparse",
         "tqdm",
         "tensorflow==2.2",
-        "nilearn",
         "pytest>=4.6",
         "pytest-cov",
         "pytest-dependency",


### PR DESCRIPTION
# Description

Removed nilearn from `setup.py`. `nilearn` no longer exists in the code.

Fixes #60

# How Has This Been Tested?

I ran
- `pip install -e .`
- `pytest ./test/output`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
