### PR TITLE
Fix/argparser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,11 @@ jobs:
         - black --check .
         - flake8 .
     - stage: "Tests"
-      name: "Output Tests: Paired Unlabeled"
+      name: "Command Tests: Unpaired Unlabeled"
+      script:
+        - train -g "" --config_path deepreg/config/unpaired_unlabeled_ddf.yaml --log_dir test
+        - predict -g "" --ckpt_path logs/test/save/weights-epoch2.ckpt --mode test
+    - name: "Output Tests: Paired Unlabeled"
       script: travis_wait 30 pytest ./test/output/test_paired_unlabeled_ddf.py
     - name: "Output Tests: Paired Labeled"
       script: travis_wait 30 pytest ./test/output/test_paired_labeled_ddf.py

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This is still under development. However some of the functionalities can be acce
 - Install DeepReg:
   `pip install -e .`
 
-- Train a registration network using test data:
-  `train --gpu <str> --config_path <str> --gpu_allow_growth --ckpt_path <str> --log <str>`
+- Train a registration network:
+  `train -g "" --config_path deepreg/config/unpaired_unlabeled_ddf.yaml --log_dir test`
 
-- Prediction using a trained registration network:
-  `predict --gpu <str> --mode <str> --ckpt_path <str> --gpu_allow_growth --log <str> --batch_size <int> --sample_label <str>`
+- Prediction using the trained registration network:
+  `predict -g "" --ckpt_path logs/test/save/weights-epoch2.ckpt --mode test`
 
 ## Tutorials
 

--- a/deepreg/dataset/load.py
+++ b/deepreg/dataset/load.py
@@ -27,7 +27,7 @@ def get_data_loader(data_config, mode):
         # when validation data is not available, use test data instead
         mode = "test"
     if mode not in modes:
-        return None
+        raise ValueError("Unknown mode {}. Supported modes are {}".format(mode, modes))
 
     data_type = data_config["type"]
     labeled = data_config["labeled"]

--- a/deepreg/model/network/ddf.py
+++ b/deepreg/model/network/ddf.py
@@ -164,7 +164,6 @@ def build_ddf_model(
     )
 
     # forward
-    print(moving_image, fixed_image, moving_label, indices)
     ddf, pred_fixed_image, pred_fixed_label = ddf_forward(
         backbone=backbone,
         moving_image=moving_image,

--- a/deepreg/predict.py
+++ b/deepreg/predict.py
@@ -277,9 +277,11 @@ def main(args=None):
     parser.add_argument(
         "--gpu",
         "-g",
-        help="GPU index for training, multiple gpus can be passed",
+        help="GPU index for training."
+        '-g "" for using CPU'
+        '-g "0" for using GPU 0'
+        '-g "0,1" for using GPU 0 and 1.',
         type=str,
-        nargs="+",
         required=True,
     )
 

--- a/deepreg/predict.py
+++ b/deepreg/predict.py
@@ -180,19 +180,31 @@ def predict_on_dataset(dataset, fixed_grid_ref, model, save_dir):
                 )
 
 
-def init(log_dir):
+def init(log_dir, ckpt_path):
     """
     Function to create new directory to log directory
     to store results.
     :param log_dir: string, path to store logs.
+    :param ckpt_path: str, path where model is stored.
     """
+    # check ckpt_path
+    if not ckpt_path.endswith(".ckpt"):
+        raise ValueError(
+            "checkpoint path should end with .ckpt, got {}".format(ckpt_path)
+        )
+
     # init log directory
-    if log_dir == "":  # default
-        log_dir = os.path.join("logs", datetime.now().strftime("%Y%m%d-%H%M%S"))
+    log_dir = os.path.join(
+        "logs", datetime.now().strftime("%Y%m%d-%H%M%S") if log_dir == "" else log_dir
+    )
     if os.path.exists(log_dir):
         logging.warning("Log directory {} exists already.".format(log_dir))
     else:
         os.makedirs(log_dir)
+
+    # load config
+    config = config_parser.load("/".join(ckpt_path.split("/")[:-2]) + "/config.yaml")
+    return config, log_dir
 
 
 def predict(gpu, gpu_allow_growth, ckpt_path, mode, batch_size, log_dir, sample_label):
@@ -208,16 +220,13 @@ def predict(gpu, gpu_allow_growth, ckpt_path, mode, batch_size, log_dir, sample_
     :param sample_label:
     """
     logging.error("TODO sample_label is not used in predict")
-    # sanity check
-    if not ckpt_path.endswith(".ckpt"):
-        raise ValueError("checkpoint path should end with .ckpt")
 
     # env vars
     os.environ["CUDA_VISIBLE_DEVICES"] = gpu
     os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "false" if gpu_allow_growth else "true"
 
     # load config
-    config = config_parser.load("/".join(ckpt_path.split("/")[:-2]) + "/config.yaml")
+    config, log_dir = init(log_dir, ckpt_path)
     data_config = config["data"]
     tf_data_config = config["tf"]["data"]
     tf_data_config["batch_size"] = batch_size
@@ -305,7 +314,7 @@ def main(args=None):
         "--mode",
         "-m",
         help="Define the split of data to be used for prediction. One of train / valid / test",
-        type=list,
+        type=str,
         default="test",
         required=True,
     )

--- a/deepreg/train.py
+++ b/deepreg/train.py
@@ -26,8 +26,9 @@ def init(config_path, log_dir, ckpt_path):
     :param ckpt_path: str, path where model is stored.
     """
     # init log directory
-    if log_dir == "":  # default
-        log_dir = os.path.join("logs", datetime.now().strftime("%Y%m%d-%H%M%S"))
+    log_dir = os.path.join(
+        "logs", datetime.now().strftime("%Y%m%d-%H%M%S") if log_dir == "" else log_dir
+    )
     if os.path.exists(log_dir):
         logging.warning("Log directory {} exists already.".format(log_dir))
     else:
@@ -96,13 +97,11 @@ def train(gpu, config_path, gpu_allow_growth, ckpt_path, log_dir):
             tf_model_config=tf_model_config,
             tf_loss_config=tf_loss_config,
         )
-        model.summary()
 
         # compile
         optimizer = opt.get_optimizer(tf_opt_config)
 
         model.compile(optimizer=optimizer)
-        print(model.summary())
 
         # load weights
         if ckpt_path != "":

--- a/deepreg/train.py
+++ b/deepreg/train.py
@@ -144,7 +144,7 @@ def main(args=None):
         help="GPU index for training."
         '-g "" for using CPU'
         '-g "0" for using GPU 0'
-        '-g "0,1\'" for using GPU 0 and 1.',
+        '-g "0,1" for using GPU 0 and 1.',
         type=str,
         required=True,
     )

--- a/deepreg/train.py
+++ b/deepreg/train.py
@@ -141,9 +141,11 @@ def main(args=None):
     parser.add_argument(
         "--gpu",
         "-g",
-        help="GPU index for training, multiple gpus can be passed",
+        help="GPU index for training."
+        '-g "" for using CPU'
+        '-g "0" for using GPU 0'
+        '-g "0,1\'" for using GPU 0 and 1.',
         type=str,
-        nargs="+",
         required=True,
     )
 
@@ -157,18 +159,28 @@ def main(args=None):
     parser.add_argument(
         "--ckpt_path",
         "-k",
-        help="Path of checkpointed model to load",
+        help="Path of the saved model checkpoint to load."
+        "No need to provide if start training from scratch.",
         default="",
         type=str,
+        required=False,
+    )
+
+    parser.add_argument(
+        "--log_dir",
+        "-l",
+        help="Path of log directory."
+        "If not provided, a timestamp based folder will be created.",
+        default="",
+        type=str,
+    )
+
+    parser.add_argument(
+        "--config_path",
+        "-c",
+        help="Path of config, must endswith .yaml.",
+        type=str,
         required=True,
-    )
-
-    parser.add_argument(
-        "--log_dir", "-l", help="Path of log directory", default="", type=str
-    )
-
-    parser.add_argument(
-        "--config_path", "-c", help="Path of config", type=str, required=True
     )
 
     args = parser.parse_args(args)

--- a/deepreg/train.py
+++ b/deepreg/train.py
@@ -168,7 +168,7 @@ def main(args=None):
     parser.add_argument(
         "--log_dir",
         "-l",
-        help="Path of log directory."
+        help="Name of log directory. The directory is under logs/."
         "If not provided, a timestamp based folder will be created.",
         default="",
         type=str,

--- a/deepreg/util.py
+++ b/deepreg/util.py
@@ -20,7 +20,7 @@ def train_and_predict_with_config(test_name, config_path):
     gpu = ""
     gpu_allow_growth = False
     ckpt_path = ""
-    log_dir = "test_" + test_name
+    log_dir = "pytest_train_" + test_name
     train(
         gpu=gpu,
         config_path=config_path,
@@ -28,7 +28,8 @@ def train_and_predict_with_config(test_name, config_path):
         ckpt_path=ckpt_path,
         log_dir=log_dir,
     )
-    ckpt_path = os.path.join(log_dir, "save", "weights-epoch2.ckpt")
+    ckpt_path = os.path.join("logs", log_dir, "save", "weights-epoch2.ckpt")
+    log_dir = "pytest_predict_" + test_name
     predict(
         gpu=gpu,
         gpu_allow_growth=gpu_allow_growth,

--- a/deepreg/util.py
+++ b/deepreg/util.py
@@ -20,7 +20,7 @@ def train_and_predict_with_config(test_name, config_path):
     gpu = ""
     gpu_allow_growth = False
     ckpt_path = ""
-    log_dir = os.path.join("logs", "test_" + test_name)
+    log_dir = "test_" + test_name
     train(
         gpu=gpu,
         config_path=config_path,


### PR DESCRIPTION
# Description

Fix the argparser
- For training, checkpoint path is not necessary. We only need this if we want to resume a training.
- For GPU, the input should be a string, not a list, so removed the line `nargs="+"`. To use multiple GPU, should pass `"0,1"`
- Also, the `log_dir` should be wrt `logs/`, it's corrected in both train and predict.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```python
train -g "" --config_path deepreg/config/unpaired_unlabeled_ddf.yaml --log_dir test
predict -g "" --ckpt_path logs/test/save/weights-epoch2.ckpt --mode test
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
